### PR TITLE
Hash passwords

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -249,7 +249,7 @@ local function handle_command(name, param)
 			return false, S("This faction doesn't exists.")
 		elseif name ~= factions.get_owner(faction_name) and not minetest.get_player_privs(name)[factions.priv] then
 			return false, S("Permission denied: You are not the owner of this faction, " ..
-				"and don't have the playerfactions_admin privilege.")
+				"and don't have the @1 privilege.", factions.priv)
 		elseif not factions.valid_password(faction_name, password) then
 			return false, S("Permission denied: Wrong password.")
 		else
@@ -336,8 +336,8 @@ local function handle_command(name, param)
 			end
 			if minetest.get_player_privs(player_name)[factions.priv] then
 				summary = summary .. "\n" .. S(
-					"@1 has the playerfactions_admin privilege so they can admin every faction.",
-					player_name
+					"@1 has the @2 privilege so they can admin every faction.",
+					player_name, factions.priv
 				)
 			end
 			return true, summary
@@ -412,7 +412,7 @@ local function handle_command(name, param)
 			return false, S("Missing player name.")
 		elseif factions.get_owner(faction_name) ~= name and not minetest.get_player_privs(name)[factions.priv] then
 			return false, S("Permission denied: You are not the owner of this faction, " ..
-				"and don't have the playerfactions_admin privilege.")
+				"and don't have the @1 privilege.", factions.priv)
 		elseif not facts[faction_name].members[target] then
 			return false, S("This player is not in the specified faction.")
 		elseif target == factions.get_owner(faction_name) then
@@ -450,7 +450,7 @@ local function handle_command(name, param)
 			return false, S("Missing password.")
 		elseif factions.get_owner(faction_name) ~= name and not minetest.get_player_privs(name)[factions.priv] then
 			return false, S("Permission denied: You are not the owner of this faction, " ..
-				"and don't have the playerfactions_admin privilege.")
+				"and don't have the @1 privilege.", factions.priv)
 		else
 			if factions.set_password(faction_name, password) then
 				return true, S("Password has been updated.")
@@ -492,7 +492,7 @@ local function handle_command(name, param)
 			return false, S("Missing password.")
 		elseif name ~= factions.get_owner(faction_name) and not minetest.get_player_privs(name)[factions.priv] then
 			return false, S("Permission denied: You are not the owner of this faction, " ..
-				"and don't have the playerfactions_admin privilege.")
+				"and don't have the @1 privilege.", factions.priv)
 		elseif not facts[faction_name].members[target] then
 			return false, S("@1 isn't in your faction.", target)
 		elseif not factions.valid_password(faction_name, password) then
@@ -506,7 +506,7 @@ local function handle_command(name, param)
 		end
 	elseif action == "invite" then
 		if not minetest.get_player_privs(name)[factions.priv] then
-			return false, S("Permission denied: You can't use this command, playerfactions_admin priv is needed.")
+			return false, S("Permission denied: You can't use this command, @1 priv is needed.", factions.priv)
 		else
 			local target = params[2]
 			local faction_name = params[3]

--- a/init.lua
+++ b/init.lua
@@ -297,9 +297,6 @@ local function handle_command(name, param)
 				end
 			end
 			local summary = S("Name: @1\nOwner: @2\nMembers: @3", faction_name, factions.get_owner(faction_name), fmembers)
-			if factions.get_owner(faction_name) == name or minetest.get_player_privs(name)[factions.priv] then
-				summary = summary .. "\n" .. S("Password: @1", factions.get_password(faction_name))
-			end
 			return true, summary
 		end
 	elseif action == "player_info" then

--- a/init.lua
+++ b/init.lua
@@ -566,3 +566,5 @@ end
 if save_needed then
 	save_factions()
 end
+
+print("[playerfactions] loaded")

--- a/init.lua
+++ b/init.lua
@@ -162,6 +162,8 @@ function factions.valid_password(fname, password)
 end
 
 function factions.get_password(fname)
+	minetest.log("warning", "Deprecated use of factions.get_password(). "
+		.. "Please update to using factions.valid_password() instead.")
 	if facts[fname] == nil then
 		return false
 	end

--- a/locale/playerfactions.fr.tr
+++ b/locale/playerfactions.fr.tr
@@ -3,12 +3,12 @@
 
 ### init.lua ###
 
-@1 has the playerfactions_admin privilege so they can admin every faction.=@1 a le privilège playerfactions_admin et peut donc administrer toutes les factions.
+@1 has the @2 privilege so they can admin every faction.=@1 a le privilège @2 et peut donc administrer toutes les factions.
 
 @1 is in the following factions: @2.=@1 est dans les factions suivantes : @2.
 @1 is now a member of the faction @2.=@1 est maintenant membre de la faction @2.
 @1 isn't in your faction.=@1 n’est pas dans votre faction.
-Add player to a faction, you need playerfactions_admin privs=Ajoute un joueur à une faction, nécessite le privilège playerfactions_admin
+Add player to a faction, you need @1 privs=Ajoute un joueur à une faction, nécessite le privilège @1
 Allow the use of all playerfactions commands=Autorise l’utilisation de toutes les commandes de playerfactions
 
 Change your faction's password or the password of the given faction=Change le mot de passe de votre faction ou la faction donnée
@@ -40,9 +40,9 @@ Password has been updated.=Le mot de passe a été mis à jour.
 Password: @1=Mot de passe : @1
 Permission denied: Wrong password.=Permission refusée : mauvais mot de passe.
 
-Permission denied: You are not the owner of this faction, and don't have the playerfactions_admin privilege.=Permission refusée : vous n’êtes pas le propriétaire de cette faction, et n’avez pas le privilège playerfactions_admin.
+Permission denied: You are not the owner of this faction, and don't have the @1 privilege.=Permission refusée : vous n’êtes pas le propriétaire de cette faction, et n’avez pas le privilège @1.
 
-Permission denied: You can't use this command, playerfactions_admin priv is needed.=Permission refusée : vous ne pouvez pas utiliser cette commande, le privilège playerfactions_admin est nécessaire.
+Permission denied: You can't use this command, @1 priv is needed.=Permission refusée : vous ne pouvez pas utiliser cette commande, le privilège @1 est nécessaire.
 
 Registered @1.=@1 enregistrée.
 See information on a faction=Voir les informations d’une faction
@@ -54,7 +54,7 @@ The faction has more than @1 members, the members list can't be shown.=Cette fac
 
 The given faction doesn't exists.=La faction en question n’existe pas.
 The player doesn't exist.=Le joueur n’existe pas.
-The player is already in the faction "@1".=Le joueur est déjà dans la faction "@1". 
+The player is already in the faction "@1".=Le joueur est déjà dans la faction "@1".
 There are no factions yet.=Il n’y a pas encore de factions.
 This faction doesn't exists.=Cette faction n’existe pas.
 The player name is nil or empty.=Le nom du joueur est nul ou vide.

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -3,12 +3,12 @@
 
 ### init.lua ###
 
-@1 has the playerfactions_admin privilege so they can admin every faction.=
+@1 has the @2 privilege so they can admin every faction.=
 
 @1 is in the following factions: @2.=
 @1 is now a member of the faction @2.=
 @1 isn't in your faction.=
-Add player to a faction, you need playerfactions_admin privs=
+Add player to a faction, you need @1 privs=
 Allow the use of all playerfactions commands=
 
 Change your faction's password or the password of the given faction=
@@ -40,9 +40,9 @@ Password has been updated.=
 Password: @1=
 Permission denied: Wrong password.=
 
-Permission denied: You are not the owner of this faction, and don't have the playerfactions_admin privilege.=
+Permission denied: You are not the owner of this faction, and don't have the @1 privilege.=
 
-Permission denied: You can't use this command, playerfactions_admin priv is needed.=
+Permission denied: You can't use this command, @1 priv is needed.=
 
 Registered @1.=
 See information on a faction=

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = playerfactions
-min_minetest_version = 5.0.0
+min_minetest_version = 5.9.0


### PR DESCRIPTION
If there are concerns about data bloat, we can probably get away with truncating the hashes or using sha1 instead of sha256.

I didn't go through the trouble to add a setting to choose the algorithm (or none), but if that is requested, I'll implement it. IMO that's just complicating things.

There is also an amendment to a previous commit snuck in this one: variable admin priv wasn't being presented to users correctly.

@louisroyer feel free to implement this in your/upstream fork.